### PR TITLE
HDPI-596 adding PACT dependencies and s2s consumer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ applicationinsights-agent-*.jar
 *.log
 /report-for-functional-tests/
 /target/
+/pacts/

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -2,6 +2,8 @@
 
 @Library("Infrastructure")
 
+import uk.gov.hmcts.contino.AppPipelineDsl
+
 def type = "java"
 def product = "enforcement"
 def component = "api"
@@ -23,11 +25,18 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   onPR() {
+    // Skipping PACT publish on PRs until contracts are verified and CONSUMER_DEPLOY_CHECK can be added
+    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     setPreviewEnvVars()
 //    afterSuccess('smoketest:preview') {
 //      runE2eTests(env.ENVIRONMENT)
 //    }
   }
+
+  onMaster() {
+    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+  }
+
   env.IDAM_S2S_AUTH_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
   loadVaultSecrets(secrets)
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -26,7 +26,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, component) {
   onPR() {
     // Skipping PACT publish on PRs until contracts are verified and CONSUMER_DEPLOY_CHECK can be added
-    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    // enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     setPreviewEnvVars()
 //    afterSuccess('smoketest:preview') {
 //      runE2eTests(env.ENVIRONMENT)

--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,6 @@ dependencies {
   testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: '6.4.4'
 
   contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.6.17'
-  contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
   contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.11.4')
   contractTestImplementation sourceSets.main.runtimeClasspath
   contractTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '6.1.0.5360'
   id 'net.serenity-bdd.serenity-gradle-plugin' version '4.2.16'
+  id 'au.com.dius.pact' version '4.6.17'
   /*
     Applies analysis tools including checkstyle and OWASP Dependency checker.
     See https://github.com/hmcts/gradle-java-plugin
@@ -48,6 +49,16 @@ sourceSets {
       srcDir file('src/smokeTest/java')
     }
     resources.srcDir file('src/smokeTest/resources')
+  }
+
+
+  contractTest {
+    java {
+      compileClasspath += main.output
+      runtimeClasspath += main.output
+      srcDir file('src/contractTest/java')
+    }
+    resources.srcDir file('src/contractTest/resources')
   }
 }
 
@@ -131,6 +142,40 @@ task smoke(type: Test) {
   description = "Runs Smoke Tests"
   testClassesDirs = sourceSets.smokeTest.output.classesDirs
   classpath = sourceSets.smokeTest.runtimeClasspath
+}
+
+task contract(type: Test) {
+  description = 'Runs the consumer Pact tests'
+  useJUnitPlatform()
+  testClassesDirs = sourceSets.contractTest.output.classesDirs
+  classpath = sourceSets.contractTest.runtimeClasspath
+  systemProperty 'pact.rootDir', "pacts"
+}
+
+task runAndPublishConsumerPactTests(type: Test){
+  testClassesDirs = sourceSets.contractTest.output.classesDirs
+  classpath = sourceSets.contractTest.runtimeClasspath
+}
+
+project.ext {
+  pactVersion = getCheckedOutGitCommitHash()
+}
+
+pact {
+  publish {
+    pactDirectory = 'pacts'
+    pactBrokerUrl = System.getenv("PACT_BROKER_URL") ?: 'http://localhost:80'
+    tags = [System.getenv("PACT_BRANCH_NAME") ?:'Dev']
+    version = project.pactVersion
+  }
+}
+
+runAndPublishConsumerPactTests.dependsOn contract
+
+runAndPublishConsumerPactTests.finalizedBy pactPublish
+
+def getCheckedOutGitCommitHash() {
+  'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
 jacocoTestReport {
@@ -222,6 +267,12 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: '6.4.4'
+
+  contractTestImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: '4.6.17'
+  contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
+  contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.11.4')
+  contractTestImplementation sourceSets.main.runtimeClasspath
+  contractTestImplementation sourceSets.test.runtimeClasspath
 }
 
 application {
@@ -238,6 +289,10 @@ bootJar {
 
 // Gradle 7.x issue, workaround from: https://github.com/gradle/gradle/issues/17236#issuecomment-894768083
 rootProject.tasks.named("processSmokeTestResources") {
+  duplicatesStrategy = 'include'
+}
+
+rootProject.tasks.named("processContractTestResources") {
   duplicatesStrategy = 'include'
 }
 

--- a/src/contractTest/java/uk/gov/hmcts/reform/enforcement/contract/ServiceAuthorisationConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/enforcement/contract/ServiceAuthorisationConsumerTest.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.reform.enforcement.contract;
+
+import au.com.dius.pact.consumer.dsl.PactDslRootValue;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableAutoConfiguration
+@TestPropertySource(properties = "idam.s2s-auth.url=http://localhost:5050")
+@ExtendWith(PactConsumerTestExt.class)
+@ExtendWith(SpringExtension.class)
+@PactTestFor(providerName = "s2s_auth", port = "5050")
+@SpringBootTest(classes = ServiceAuthorisationApi.class)
+@EnableFeignClients(basePackages = "uk.gov.hmcts.reform.idam.client")
+
+public class ServiceAuthorisationConsumerTest {
+
+    private static final String AUTHORISATION_TOKEN = "Bearer someAuthorisationToken";
+    public static final String MICRO_SERVICE_NAME = "someMicroServiceName";
+    public static final String MICRO_SERVICE_TOKEN = "someMicroServiceToken";
+
+    @Autowired
+    private ServiceAuthorisationApi serviceAuthorisationApi;
+
+    @Pact(provider = "s2s_auth", consumer = "pcs_api")
+    public V4Pact executeLease(PactDslWithProvider builder) throws JsonProcessingException {
+
+        return builder
+            .given("microservice with valid credentials")
+            .uponReceiving("a request for a token")
+            .path("/lease")
+            .method(HttpMethod.POST.toString())
+            .body("{\"microservice\":\"" + MICRO_SERVICE_NAME + "\", \"oneTimePassword\":\"784467\"}")
+            .willRespondWith()
+            .headers(Map.of(HttpHeaders.CONTENT_TYPE, "text/plain"))
+            .status(HttpStatus.OK.value())
+            .body(PactDslRootValue.stringType(MICRO_SERVICE_TOKEN))
+            .toPact(V4Pact.class);
+    }
+
+    @Pact(provider = "s2s_auth", consumer = "pcs_api")
+    public V4Pact executeDetails(PactDslWithProvider builder) throws JsonProcessingException {
+
+        return builder.given("microservice with valid token")
+            .uponReceiving("a request to validate details")
+            .path("/details")
+            .headers(HttpHeaders.AUTHORIZATION, AUTHORISATION_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .headers(Map.of(HttpHeaders.CONTENT_TYPE, "text/plain"))
+            .status(HttpStatus.OK.value())
+            .body(PactDslRootValue.stringType(MICRO_SERVICE_NAME))
+            .toPact(V4Pact.class);
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "executeLease")
+    void verifyLease() {
+
+        Map<String, String> jsonPayload = new HashMap<>();
+        jsonPayload.put("microservice", MICRO_SERVICE_NAME);
+        jsonPayload.put("oneTimePassword", "784467");
+
+        String token = serviceAuthorisationApi.serviceToken(jsonPayload);
+        assertThat(token)
+            .isEqualTo(MICRO_SERVICE_TOKEN);
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "executeDetails")
+    void verifyDetails() {
+
+        String token = serviceAuthorisationApi.getServiceName(AUTHORISATION_TOKEN);
+        assertThat(token)
+            .isEqualTo(MICRO_SERVICE_NAME);
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/enforcement/contract/ServiceAuthorisationConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/enforcement/contract/ServiceAuthorisationConsumerTest.java
@@ -42,7 +42,7 @@ public class ServiceAuthorisationConsumerTest {
     @Autowired
     private ServiceAuthorisationApi serviceAuthorisationApi;
 
-    @Pact(provider = "s2s_auth", consumer = "pcs_api")
+    @Pact(provider = "s2s_auth", consumer = "enforcement_api")
     public V4Pact executeLease(PactDslWithProvider builder) throws JsonProcessingException {
 
         return builder
@@ -58,7 +58,7 @@ public class ServiceAuthorisationConsumerTest {
             .toPact(V4Pact.class);
     }
 
-    @Pact(provider = "s2s_auth", consumer = "pcs_api")
+    @Pact(provider = "s2s_auth", consumer = "enforcement_api")
     public V4Pact executeDetails(PactDslWithProvider builder) throws JsonProcessingException {
 
         return builder.given("microservice with valid token")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HDPI-596

### Change description ###

This PR introduces PACT dependencies and implements the first set of consumer contract tests with s2s-auth.
Able to see that contacts are being published and verified in Pact Broker HMCTS:
<img width="1281" alt="Screenshot 2025-04-11 at 17 31 31" src="https://github.com/user-attachments/assets/9fc8f31d-260c-478c-a57e-97b95df1a06c" />

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
