### PR TITLE
Small fix to the routing of openAPI publisher tests to fix github actions

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -10,5 +10,5 @@ jobs:
     secrets:
       SWAGGER_PUBLISHER_API_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
     with:
-      test_to_run: 'uk.gov.hmcts.reform.demo.openapi.OpenAPIPublisherTest'
+      test_to_run: 'uk.gov.hmcts.reform.enforcement.openapi.OpenAPIPublisherTest'
       java_version: 17


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Small fix to the routing of openAPI publisher tests to fix github actions

**Does this PR introduce a breaking change?** (check one with "x")


[ ] Yes
[x] No
