### PR TITLE
Setting tomcat embed core & websocket to remove CVE's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,8 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.44'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.44'
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -270,7 +270,7 @@ ext {
   springSecurityVersion = "6.5.2"
   pactVersion = "4.6.17"
   dbSchedulerVersion = "16.0.0"
-  tomcatCoreVersion = "10.1.44"
+  tomcatEmbedVersion = "10.1.44"
 }
 
 ext['snakeyaml.version'] = '2.2'
@@ -308,8 +308,8 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatCoreVersion
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatCoreVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatEmbedVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatEmbedVersion
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.5'
 

--- a/build.gradle
+++ b/build.gradle
@@ -270,6 +270,7 @@ ext {
   springSecurityVersion = "6.5.2"
   pactVersion = "4.6.17"
   dbSchedulerVersion = "16.0.0"
+  tomcatCoreVersion = "10.1.44"
 }
 
 ext['snakeyaml.version'] = '2.2'
@@ -307,8 +308,8 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
   implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.44'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.44'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatCoreVersion
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: tomcatCoreVersion
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured', version: '5.5.5'
 


### PR DESCRIPTION
### Jira link

N/A

### Change description

Setting tomcat embed core & web socket to remove CVE's, please note this is a minor package upgrade as they are a sub dependency of spring-boot-starter-web@3.5.4 and ccd-config-generator@0.20.0-alpha.37, where they are set to version 10.1.43.

### Testing done

Automated tests

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
